### PR TITLE
Correct diacritic for French phrase

### DIFF
--- a/src/epub/text/chapter-9.xhtml
+++ b/src/epub/text/chapter-9.xhtml
@@ -76,7 +76,7 @@
 			<p>Possessed by some sudden idea, or pressed to action by his tumultuous thoughts, he snatched up a lantern and strode silently off across the grass and to the shrubbery once more. I followed him. I think his idea was that he might surprise anyone who lurked there. He surprised himself, and all of us.</p>
 			<p>For right at the margin he tripped and fell flat. I ran to him.</p>
 			<p>He had fallen over the body of Denby, which lay there!</p>
-			<p>Denby had not been there a few moments before, and how he came to be there now we dared not conjecture. <abbr>Mr.</abbr> Eltham joined us, uttered one short, dry sob, and dropped upon his knees. Then we were carrying Denby back to the house, with the mastiff howling a <i xml:lang="fr">marche funebre</i>.</p>
+			<p>Denby had not been there a few moments before, and how he came to be there now we dared not conjecture. <abbr>Mr.</abbr> Eltham joined us, uttered one short, dry sob, and dropped upon his knees. Then we were carrying Denby back to the house, with the mastiff howling a <i xml:lang="fr">marche funèbre</i>.</p>
 			<p>We laid him on the grass where it sloped down from the terrace. Nayland Smith’s haggard face was terrible. But the stark horror of the thing inspired him to that, which conceived earlier, had saved Denby. Twisting suddenly to Eltham, he roared in a voice audible beyond the river:</p>
 			<p>“Heavens! we are fools! <em>Loose the dog!</em>”</p>
 			<p>“But the dog⁠—” I began.</p>


### PR DESCRIPTION
Just a single spelling mistake in a French phrase: https://fr.wikipedia.org/wiki/Marche_fun%C3%A8bre . No credit needed.
